### PR TITLE
restore compatibility with phpunit 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /tools
 /vendor
 /build
+/.phpunit.result.cache

--- a/tests/TokenCollectionTest.php
+++ b/tests/TokenCollectionTest.php
@@ -33,7 +33,11 @@ class TokenCollectionTest extends TestCase {
         $this->collection->addToken($token);
 
         foreach($this->collection as $position => $current) {
-            $this->assertIsInt($position);
+            if (method_exists($this, 'assertIsInt')) {
+               $this->assertIsInt($position);
+            } else {
+               $this->assertInternalType('integer', $position);
+            }
             $this->assertSame($token, $current);
         }
     }


### PR DESCRIPTION
`assertIsInt` was introduce in PHPUnit 7 which requires PHP 7.1
As this library is compatible with PHP 7.0, I think it makes sense to keep compatibility with PHPUnit 6 to be able to run test suite with all supported versions.

```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.17
Configuration: /work/GIT/tokenizer/phpunit.xml
Error:         No code coverage driver is available

...................                                               19 / 19 (100%)

Time: 55 ms, Memory: 4,00MB

OK (19 tests, 26 assertions)

PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.17
Configuration: /work/GIT/tokenizer/phpunit.xml
Error:         No code coverage driver is available

...................                                               19 / 19 (100%)

Time: 42 ms, Memory: 4,00MB

OK (19 tests, 26 assertions)

PHPUnit 7.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.17
Configuration: /work/GIT/tokenizer/phpunit.xml
Error:         No code coverage driver is available

...................                                               19 / 19 (100%)

Time: 41 ms, Memory: 4,00 MB

OK (19 tests, 26 assertions)

PHPUnit 8.0.6 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.17
Configuration: /work/GIT/tokenizer/phpunit.xml
Error:         No code coverage driver is available

...................                                               19 / 19 (100%)

Time: 45 ms, Memory: 6,00 MB

OK (19 tests, 26 assertions)

```