### PR TITLE
Add .gitattribute file with export-ignore rules to minimize dist size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.github         export-ignore
+/tests           export-ignore
+/.gitattributes  export-ignore
+/.gitignore      export-ignore
+/.php_cs         export-ignore
+/.travis.yml     export-ignore
+/build.xml       export-ignore
+/phive.xml       export-ignore
+/phpunit.xml     export-ignore


### PR DESCRIPTION
Hi Arne,
I'd like to propose that we use a `.gitattributes` file with `export-ignore` rules to make Github not include tests and other build files in the zip file. 

As of now, the code:test+build file size ratio is about 55:12.3 (in kilobytes). So this means we effectively reduce the file size of this package by 55kb.

Thank you for all your great work in this library 🙏.