### PR TITLE
Update ci.yml replacing GitHub Actions V2 (Deprecated) for V3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -39,7 +39,7 @@ jobs:
           tools: phive
 
       - name: Install java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'zulu'


### PR DESCRIPTION
This PR updates the GitHub Actions V2 (which are deprecated) for V3. This would avoid warning in the action runs.

## Additional context
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/