### PR TITLE
Remove unused `use var_dump` statement

### DIFF
--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types = 1);
 namespace TheSeer\Tokenizer;
 
-use function var_dump;
-
 class Tokenizer {
 
     /**


### PR DESCRIPTION
Removes 1 unused `var_dump` function `use` statement from `Tokenizer.php`