### PR TITLE
Simplify XMLSerializer

### DIFF
--- a/src/XMLSerializer.php
+++ b/src/XMLSerializer.php
@@ -5,9 +5,6 @@ use DOMDocument;
 
 class XMLSerializer {
 
-    /** @var Token */
-    private $previousToken;
-
     /** @var NamespaceUri */
     private $xmlns;
 
@@ -43,15 +40,15 @@ class XMLSerializer {
             $writer->startElement('line');
             $writer->writeAttribute('no', '1');
 
-            $this->previousToken = $tokens[0];
+            $previousToken = $tokens[0];
 
             foreach ($tokens as $token) {
-                if ($this->previousToken->getLine() < $token->getLine()) {
+                if ($previousToken->getLine() < $token->getLine()) {
                     $writer->endElement();
         
                     $writer->startElement('line');
                     $writer->writeAttribute('no', (string)$token->getLine());
-                    $this->previousToken = $token;
+                    $previousToken = $token;
                 }
         
                 if ($token->getValue() !== '') {


### PR DESCRIPTION
reduce number of method calls on a hot path while phpunit code coverage generation, see profiles in https://github.com/sebastianbergmann/php-code-coverage/pull/1102

idea is to 
- use more local variables, so garbage collector has less work
- use less method calls on a very hot path

<img width="1240" height="448" alt="grafik" src="https://github.com/user-attachments/assets/46323f43-62a6-4917-917f-4b64e1d3a4e3" />
