### PR TITLE
Fix asymmetry in startElement() and endElement()

### DIFF
--- a/src/XMLSerializer.php
+++ b/src/XMLSerializer.php
@@ -62,9 +62,10 @@ class XMLSerializer {
                     $writer->endElement();
                 }
             }
+
+            $writer->endElement();
         }
 
-        $writer->endElement();
         $writer->endElement();
         $writer->endDocument();
 


### PR DESCRIPTION
doesn't matter for the overall outcome, but my inner monk doesn't link code which starts things only under certain conditions, but ends them every time :)